### PR TITLE
[Fix] Add ollama message API support for text

### DIFF
--- a/cognify/frontends/dspy/connector.py
+++ b/cognify/frontends/dspy/connector.py
@@ -71,7 +71,14 @@ class PredictModel(dspy.Module):
 
         # lm config
         lm_client: dspy.LM = dspy.settings.get("lm", None)
-        assert lm_client, "Expected lm client, got none"
+
+        should_hint = False
+        if lm_client.model.startswith("ollama"):
+            # ollama prompts us to include some json instruction in the system prompt
+            should_hint = True
+            system_prompt += " Please provide your answer in JSON format according to the instructions provided next."
+        
+        assert lm_client, "Expected lm to be configured in dspy"
         lm_config = LMConfig(model=lm_client.model, kwargs=lm_client.kwargs)
 
         # always treat as structured to provide compatiblity with forward function
@@ -79,7 +86,8 @@ class PredictModel(dspy.Module):
             agent_name=name,
             system_prompt=system_prompt,
             input_variables=input_variables,
-            output_format=OutputFormat(schema=self.output_schema),
+            output_format=OutputFormat(schema=self.output_schema, 
+                                       should_hint_format_in_prompt=should_hint),
             lm_config=lm_config,
         )
 

--- a/cognify/hub/cogs/tree_of_thoughts/tot.py
+++ b/cognify/hub/cogs/tree_of_thoughts/tot.py
@@ -56,7 +56,7 @@ class TreeOfThought(ReasonThenFormat):
         prompt = copy.deepcopy(current_messages)
         prompt.append({"role": "user", "content": "What should we consider next?"})
         for _ in range(self.beam_width):
-            response = completion(self.model, prompt, **self.model_kwargs)
+            response = litellm_completion(self.model, prompt, self.model_kwargs)
             self.model_responses.append(response)
             new_path = current_messages + [
                 {
@@ -80,7 +80,7 @@ class TreeOfThought(ReasonThenFormat):
                     "content": "Please rate the quality of the reasoning so far on a scale of 1 to 10.",
                 }
             ]
-            evaluation = completion(self.model, eval_prompt, **self.model_kwargs)
+            evaluation = litellm_completion(self.model, eval_prompt, self.model_kwargs)
             self.model_responses.append(evaluation)
             score = self.extract_score(evaluation.choices[0].message.content)
             scored_candidates.append((score, candidate))

--- a/cognify/llm/__init__.py
+++ b/cognify/llm/__init__.py
@@ -2,14 +2,17 @@ from .model import Model, StructuredModel, LMConfig
 from .prompt import Input, Demonstration, FilledInput
 from .output import OutputLabel, OutputFormat
 from .response import StepInfo
+from .litellm_wrapper import litellm_completion
 
 __all__ = [
     "Model",
     "StructuredModel",
     "Input",
+    "FilledInput",
     "LMConfig",
     "Demonstration",
     "OutputLabel",
     "OutputFormat",
     "StepInfo",
+    "litellm_completion",
 ]

--- a/cognify/llm/litellm_wrapper.py
+++ b/cognify/llm/litellm_wrapper.py
@@ -1,0 +1,29 @@
+from litellm import completion
+from pydantic import BaseModel
+
+def litellm_completion(model: str, messages: list, model_kwargs: dict, response_format: BaseModel = None):
+    if response_format:
+        model_kwargs["response_format"] = response_format
+
+    # handle ollama
+    if model.startswith("ollama"):
+        for msg in messages:
+            concatenated_text_content = ""
+            if isinstance(msg["content"], list):
+                for entry in msg["content"]:
+                    # Ollama image API support: https://github.com/GenseeAI/cognify/issues/11
+                    assert entry["type"] != "image_url", "Image support for ollama coming soon."
+                    concatenated_text_content += entry["text"]
+                msg["content"] = concatenated_text_content
+    
+        if response_format:
+            del model_kwargs["response_format"]
+            model_kwargs["format"] = response_format.model_json_schema()
+    
+    response = completion(
+        model,
+        messages,
+        **model_kwargs
+    )
+
+    return response

--- a/cognify/llm/model.py
+++ b/cognify/llm/model.py
@@ -528,7 +528,12 @@ class StructuredModel(Model):
 
             if model.startswith("ollama"):
                 for msg in messages_updated:
-                    msg["content"] = msg["content"][0]["text"]
+                    concatenated_content = ""
+                    for entry in msg["content"]:
+                        assert entry["type"] != "image_url", "Image support for ollama coming soon."
+                        concatenated_content += entry["text"]
+                    msg["content"] = concatenated_content
+
                 response = completion(
                     model,
                     messages_updated,

--- a/cognify/llm/model.py
+++ b/cognify/llm/model.py
@@ -524,12 +524,25 @@ class StructuredModel(Model):
             )
         else:
             model = model_kwargs.pop("model")
-            response = completion(
-                model,
-                self._get_api_compatible_messages(messages),
-                response_format=self.output_format.schema,
-                **model_kwargs,
-            )
+            messages_updated = self._get_api_compatible_messages(messages)
+
+            if model.startswith("ollama"):
+                for msg in messages_updated:
+                    msg["content"] = msg["content"][0]["text"]
+                response = completion(
+                    model,
+                    messages_updated,
+                    format=self.output_format.schema.model_json_schema(),
+                    **model_kwargs,
+                )
+            else:
+                response = completion(
+                    model,
+                    messages_updated,
+                    response_format=self.output_format.schema,
+                    **model_kwargs,
+                )
+            
             return response
 
     @override

--- a/cognify/optimizer/evaluator.py
+++ b/cognify/optimizer/evaluator.py
@@ -301,32 +301,41 @@ class EvalTask:
                     )
             
             start_time = time.time()
-            result = schema.program(**input)
             end_time = time.time()
-            # merge input/result/label to a single dict
-            state = {**input, **result, **label}
-            score = evaluator.score(state)
-
-            # get price and demo of running the program
+            score = 0.0
+            result = None   # this value is unused in `get_score`, so we can set this to `None` -- should refactor this
             price = 0.0
             lm_to_demo = {}
-            for lm in Module.all_of_type(module_pool.values(), Model):
-                price += lm.get_total_cost()
-                demo = lm.get_last_step_as_demo()
-                if demo is not None:
-                    lm_to_demo[lm.name] = demo
 
-            q.put(
-                (
-                    task_index,
-                    True,
-                    result,
-                    score,
-                    price,
-                    lm_to_demo,
-                    end_time - start_time,
+            try:
+                result = schema.program(**input)
+                end_time = time.time()
+                # merge input/result/label to a single dict
+                state = {**input, **result, **label}
+                score = evaluator.score(state)
+            except Exception as e:
+                # catch any errors thrown during the workflow and treat as an invalid result
+                logger.error(f"Workflow execution threw error for task {task_index}: {e}. Automatic 0")
+                end_time = time.time()  # this isn't accurate if the process is interrupted
+            finally:
+                # get price and demo of running the program
+                for lm in Module.all_of_type(module_pool.values(), Model):
+                    price += lm.get_total_cost()
+                    demo = lm.get_last_step_as_demo()
+                    if demo is not None:
+                        lm_to_demo[lm.name] = demo
+
+                q.put(
+                    (
+                        task_index,
+                        True,
+                        result, # this value is unused in `get_score`
+                        score,
+                        price,
+                        lm_to_demo,
+                        end_time - start_time,
+                    )
                 )
-            )
         except KeyboardInterrupt:
             q.put((task_index, False, None, 0.0, 0.0, None, 0.0))
         except Exception as e:

--- a/cognify/optimizer/evaluator.py
+++ b/cognify/optimizer/evaluator.py
@@ -314,8 +314,9 @@ class EvalTask:
                 state = {**input, **result, **label}
                 score = evaluator.score(state)
             except Exception as e:
-                # catch any errors thrown during the workflow and treat as an invalid result
-                logger.error(f"Workflow execution threw error for task {task_index}: {e}. Automatic 0")
+                # catch any errors thrown during the workflow and treat as an invalid result by scoring 0
+                # Note: scoring 0 may be problematic if the evaluator's range includes negative numbers
+                logger.error(f"Workflow execution threw error for task {task_index}: {e}. Automatic score of 0")
                 end_time = time.time()  # this isn't accurate if the process is interrupted
             finally:
                 # get price and demo of running the program

--- a/examples/HoVeR/config.py
+++ b/examples/HoVeR/config.py
@@ -1,7 +1,7 @@
 import cognify
 from cognify.hub.evaluators import f1_score_set
 
-@cognify.register_opt_score_fn
+@cognify.register_evaluator
 def doc_f1(pred_docs, gold_docs):
     pred_docs = set(pred_docs)
     gold_docs = set(gold_docs)

--- a/examples/HotPotQA/config.py
+++ b/examples/HotPotQA/config.py
@@ -1,7 +1,7 @@
 import cognify
 from cognify.hub.evaluators import f1_score_str
 
-@cognify.register_opt_score_fn
+@cognify.register_evaluator
 def answer_f1(answer: str, ground_truth: str):
     return f1_score_str(answer, ground_truth)
 


### PR DESCRIPTION
Closes #10 

- [x] Adds a wrapper around `litellm.completion` which parses down the message from `"content": [{"type": "text", "text": "xyz"}]` to `"content": "xyz"` for ollama. As mentioned in #11 , the former _should_ still be compatible when looking at the ollama codebase, so we should investigate in more detail when making the fix for images.
- [x] Add error handling for DSPy in case structured output returns an empty value for an expected field

Also adds the following:
- [x] Add evaluator-level error handling in case a workflow throws an error. Instead of raising the error and exiting, we log the error and treat that individual result as invalid. The use case for this is the model generating output that is "wrong" from the perspective of the workflow developer (e.g., not structured correctly, incorrect tool call). The workflow will throw an error upon executing. But since it may be specific to a particular training example or non-deterministic, we shouldn't kill the optimizer. **If this is controversial, I can move it to a separate PR and we can merge this one.**   