### PR TITLE
[Feat] Add `cognify run` to CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ compiler_logs/
 
 local_testing/
 **initial_run
+*.pkl
 
 # secrets
 secrets.toml

--- a/cognify/__init__.py
+++ b/cognify/__init__.py
@@ -13,7 +13,8 @@ from .frontends.langchain.connector import RunnableModel, as_runnable
 
 from cognify import llm, optimizer
 
-from cognify.run.evaluate import evaluate, load_workflow
+from cognify.run.evaluate import evaluate
+from cognify.run.run import run, load_workflow
 from cognify.run.optimize import optimize
 from cognify.run.inspect import inspect
 from cognify.optimizer import (
@@ -37,6 +38,7 @@ __all__ = [
     "load_workflow",
     "optimize",
     "inspect",
+    "run",
     "EvaluationResult",
     "create_default_search",
     "register_workflow",

--- a/cognify/__main__.py
+++ b/cognify/__main__.py
@@ -7,6 +7,7 @@ from cognify.cognify_args import (
     OptimizationArgs,
     EvaluationArgs,
     InspectionArgs,
+    RunArgs,
 )
 from cognify.optimizer.plugin import capture_module_from_fs
 from cognify.optimizer.registry import get_registered_data_loader
@@ -14,6 +15,7 @@ from cognify.optimizer.control_param import ControlParameter
 from cognify.run.optimize import optimize
 from cognify.run.evaluate import evaluate
 from cognify.run.inspect import inspect
+from cognify.run.run import run
 from cognify._logging import _configure_logger
 from cognify._tracing import trace_cli_args, trace_workflow, initial_usage_message
 
@@ -27,6 +29,8 @@ def from_cognify_args(args):
         return EvaluationArgs.from_cli_args(args)
     elif args.mode == "inspect":
         return InspectionArgs.from_cli_args(args)
+    elif args.mode == "run":
+        return RunArgs.from_cli_args(args)
     else:
         raise ValueError(f"Unknown mode: {args.mode}")
 
@@ -99,6 +103,14 @@ def inspect_routine(inspect_args: InspectionArgs):
         dump_frontier_details=inspect_args.dump_optimization_results,
     )
 
+def run_routine(run_args: RunArgs):
+    _, control_param = parse_pipeline_config_file(run_args.config, load_data=False)
+    run(
+        config_id=run_args.select,
+        workflow=run_args.workflow,
+        input=run_args.input,
+        control_param=control_param
+    )
 
 def main():
     initial_usage_message()
@@ -119,8 +131,12 @@ def main():
         optimize_routine(cognify_args)
     elif raw_args.mode == "evaluate":
         evaluate_routine(cognify_args)
-    else:
+    elif raw_args.mode == "inspect":
         inspect_routine(cognify_args)
+    elif raw_args.mode == "run":
+        run_routine(cognify_args)
+    else:
+        raise ValueError(f"Unknown mode: {raw_args.mode}")
     return
 
 

--- a/cognify/cognify_args.py
+++ b/cognify/cognify_args.py
@@ -133,6 +133,30 @@ class InspectionArgs(CommonArgs):
             help="Dump descriptive optimization details.",
         )
 
+@dataclasses.dataclass
+class RunArgs(CommonArgs):
+    select: str = 'Original'
+    input: str = ""
+
+    @staticmethod
+    def add_cli_args(parser):
+        CommonArgs.add_cli_args(parser)
+        parser.add_argument(
+            "--select",
+            type=str,
+            required=True,
+            default=EvaluationArgs.select,
+            help="Select one configuration by ID for evaluation. If evaluating the original workflow, use 'Original'.",
+            metavar="Optimization_x/Original",
+        )
+        parser.add_argument(
+            "-i",
+            "--input",
+            type=str,
+            default=RunArgs.input,
+            help="Input string for the workflow (currently only single input supported).",
+            metavar="input_string",
+        )
 
 def init_cognify_args(parser):
     subparsers = parser.add_subparsers(dest="mode")
@@ -152,3 +176,8 @@ def init_cognify_args(parser):
         "inspect", formatter_class=argparse.RawTextHelpFormatter
     )
     InspectionArgs.add_cli_args(inspect_parser)
+
+    run_parser = subparsers.add_parser(
+        "run", formatter_class=argparse.RawTextHelpFormatter
+    )
+    RunArgs.add_cli_args(run_parser)

--- a/cognify/run/evaluate.py
+++ b/cognify/run/evaluate.py
@@ -114,24 +114,3 @@ def evaluate(
     return result
 
 
-def load_workflow(
-    *,
-    config_id: str,
-    opt_result_path: Optional[str] = None,
-    control_param: Optional[ControlParameter] = None,
-) -> Callable:
-    assert (
-        control_param or opt_result_path
-    ), "Either control_param or opt_result_path should be provided"
-    # If both are provided, control_param will be used
-
-    if control_param is None:
-        control_param_save_path = os.path.join(opt_result_path, "control_param.json")
-        control_param = ControlParameter.from_json_profile(control_param_save_path)
-
-    opt_driver = driver.MultiLayerOptimizationDriver(
-        layer_configs=control_param.opt_layer_configs,
-        opt_log_dir=control_param.opt_history_log_dir,
-    )
-    schema, _ = opt_driver.load(config_id)
-    return schema.program

--- a/cognify/run/run.py
+++ b/cognify/run/run.py
@@ -1,0 +1,54 @@
+import os
+from typing import Optional, Callable
+import logging
+
+from cognify.optimizer.control_param import ControlParameter
+from cognify.optimizer.core import driver
+from cognify.optimizer.plugin import OptimizerSchema
+
+from cognify._signal import _should_exit, _init_exit_gracefully
+
+_init_exit_gracefully(msg="Stopping main", verbose=True)
+
+logger = logging.getLogger(__name__)
+
+def run(
+    *,
+    config_id: str,
+    workflow: str,
+    input: str,
+    control_param: Optional[ControlParameter] = None,
+):
+    if config_id == 'Original':
+        print("Loading original workflow")
+        program = OptimizerSchema.capture(workflow).program
+    else:
+        print(f"Loading workflow with {config_id}")
+        program = load_workflow(config_id=config_id, control_param=control_param)
+    print(f"Running the following input: '{input}'...")
+    result = program(input)
+    print(result)
+
+
+def load_workflow(
+    *,
+    config_id: str,
+    opt_result_path: Optional[str] = None,
+    control_param: Optional[ControlParameter] = None,
+) -> Callable:
+    assert (
+        control_param or opt_result_path
+    ), "Either control_param or opt_result_path should be provided"
+    # If both are provided, control_param will be used
+
+    if control_param is None:
+        control_param_save_path = os.path.join(opt_result_path, "control_param.json")
+        control_param = ControlParameter.from_json_profile(control_param_save_path)
+
+    opt_driver = driver.MultiLayerOptimizationDriver(
+        layer_configs=control_param.opt_layer_configs,
+        opt_log_dir=control_param.opt_history_log_dir,
+        objectives=control_param.objectives,
+    )
+    schema, _ = opt_driver.load(config_id)
+    return schema.program

--- a/cognify/run/run.py
+++ b/cognify/run/run.py
@@ -27,7 +27,7 @@ def run(
         program = load_workflow(config_id=config_id, control_param=control_param)
     print(f"Running the following input: '{input}'...")
     result = program(input)
-    print(result)
+    print(f"Output: {result.values()[0]}")
 
 
 def load_workflow(

--- a/docs/source/user_guide/tutorials/interpret.rst
+++ b/docs/source/user_guide/tutorials/interpret.rst
@@ -222,3 +222,14 @@ You can evaluate the optimized workflow on the test data with:
 
     new_workflow = cognify.load_workflow(config_id='Optimization_3', opt_result_path='opt_results')
     answer = new_workflow(problem)
+
+**Command-line Interface**
+
+You can run a single request using the command line interface (CLI) as well:
+
+.. code-block:: console
+
+    $ cognify run workflow.py --select Optimization_3 --input "A bored student walks down a hall that contains a row of closed lockers..."
+    Loading workflow with Optimization_3
+    Running the following input: A bored student walks down a hall that contains a row of closed lockers...
+    Output: The last locker he opens is 342.

--- a/examples/HotPotQA/config.py
+++ b/examples/HotPotQA/config.py
@@ -25,9 +25,8 @@ def load_data():
     devset = [formatting(x) for x in dataset.dev]
     return trainset, valset, devset # training and evaluation data
 
-from cognify.hub.search import default
-search_settings = default.create_search(
+from cognify.hub.search import qa
+search_settings = qa.create_search(
     evaluator_batch_size=12,
-    opt_log_dir='demo_results_test',
-    n_trials=5
+    opt_log_dir='hotpot_results'
 )

--- a/examples/HotPotQA/workflow.py
+++ b/examples/HotPotQA/workflow.py
@@ -4,7 +4,7 @@ dotenv.load_dotenv()
 
 import dspy
 
-gpt4o_mini = dspy.LM('gpt-4o-mini', max_tokens=1000)
+gpt4o_mini = dspy.LM('gpt-4o', max_tokens=1000)
 colbert = dspy.ColBERTv2(url=os.environ['COLBERT_URL'])
 
 dspy.configure(lm=gpt4o_mini, rm=colbert)


### PR DESCRIPTION
Close #30
Supersedes #31 

This supports a single input string, which corresponds to a single argument for the workflow entry point.

i.e. this PR supports workflows like:
```
def my_workflow(question):
    ...
```

but not like:
```
def my_workflow(question, document):
    ...
```

The latter is possible but will require some more parsing of the input command line arguments.