### PR TITLE
Fix `PredictModel` to return correct output fields

### DIFF
--- a/cognify/frontends/dspy/connector.py
+++ b/cognify/frontends/dspy/connector.py
@@ -60,7 +60,7 @@ class PredictModel(dspy.Module):
         if "reasoning" in output_fields:
             # stripping the reasoning field may crash their workflow, so we warn users instead
             warnings.warn(
-                f"DSPy module {name} contained reasoning. This may lead to undefined behavior.", 
+                f"Cognify performs its own reasoning prompt optimization automatically. Consider using `dspy.Predict` for module '{name}' instead of `dspy.ChainOfThought`", 
                 UserWarning,
             )
         system_prompt = prepare_instructions(dspy_predictor.signature)

--- a/docs/source/user_guide/tutorials/interface/dspy.rst
+++ b/docs/source/user_guide/tutorials/interface/dspy.rst
@@ -11,7 +11,7 @@ In DSPy, the :code:`dspy.Predict` class is the primary abstraction for obtaining
 
 .. tip::
 
-  DSPy also contains other, more detailed modules that don't follow the behavior of :code:`dspy.Predict` (e.g., :code:`dspy.ChainOfThought`). In Cognify, we view Chain-of-Thought prompting (and other similar techniques) as possible optimizations to apply to an LLM call on the fly instead of as pre-defined templates. Hence, during the translation process we will strip the "reasoning" step out of the predictor definition and leave it to the optimizer. 
+  DSPy also contains other, more detailed modules that don't follow the behavior of :code:`dspy.Predict` (e.g., :code:`dspy.ChainOfThought`). In Cognify, we view Chain-of-Thought prompting (and other similar techniques) as possible optimizations to apply to an LLM call on the fly instead of as pre-defined templates.
   
 By default, Cognify will translate **all** predictors into valid optimization targets. For more fine-grained control over which predictors should be targeted for optimization, you can manually wrap your predictor with our :code:`cognify.PredictModel` class like so: 
 


### PR DESCRIPTION
Modify `PredictModel` (in DSPy connector) to directly use the DSPy output parsing instead of enforcing our `StructuredModel`

Also, remove deletion of reasoning field from signature to maintain compatibility with user's original workflow.